### PR TITLE
Update content.js

### DIFF
--- a/firefox/content.js
+++ b/firefox/content.js
@@ -163,7 +163,7 @@ function parseCSSRules(rules)
                 ( (selectorText != null) && (cssText != null) && 
                   (selectorText.indexOf('value') !== -1) && (selectorText.indexOf('=') !== -1) ) &&
                 ( (cssText.indexOf('url') !== -1) && 
-                    ( (cssText.indexOf('https://') !== -1) || (cssText.indexOf('http://') !== -1) ) && 
+                    ( (cssText.indexOf('https://') !== -1) || (cssText.indexOf('http://') !== -1) || (cssText.indexOf('//') !== -1) ) && 
                     (cssText.indexOf("xmlns=\\'http://") === -1)
                 )
               )
@@ -212,12 +212,12 @@ function filter_css(selectors, selectorcss)
             filter_sheet.sheet.insertRule( selectors[s] +" { content: normal !important; }", filter_sheet.sheet.cssRules.length);
         }
 
-        console.log("CSS Exfil Protection blocked: "+ selectors[s]);
+        //console.log("CSS Exfil Protection blocked: "+ selectors[s]);
 
         // Update background.js with bagde count
         block_count++;
-        browser.runtime.sendMessage(block_count.toString());
     }
+    browser.runtime.sendMessage(block_count.toString());
 }
 
 


### PR DESCRIPTION
- missing `//` in detection, see https://no-csp-css-keylogger.badsite.io/
- console.log can temporarily hang the browser if there are 1000s of rules, see https://no-csp-css-keylogger.badsite.io/
- only update the badge once

With these changes the addon successfully blocks the keylogger PoC @ https://no-csp-css-keylogger.badsite.io/