### PR TITLE
Add some security to link in the extension

### DIFF
--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -23,7 +23,7 @@
     </label>
 
     <footer>
-        <a target="_blank" href="https://www.mike-gualtieri.com/css-exfil-vulnerability-tester"/>About CSS Exfil Protection</a>
+        <a target="_blank" rel=”noreferrer noopener” href="https://www.mike-gualtieri.com/css-exfil-vulnerability-tester"/>About CSS Exfil Protection</a>
     </footer>
 
   <script type="text/javascript" src="popup.js"></script>

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -23,7 +23,7 @@
     </label>
 
     <footer>
-        <a target="_blank" href="https://www.mike-gualtieri.com/css-exfil-vulnerability-tester"/>About CSS Exfil Protection</a>
+        <a target="_blank" rel=”noreferrer noopener” href="https://www.mike-gualtieri.com/css-exfil-vulnerability-tester"/>About CSS Exfil Protection</a>
     </footer>
 
   <script type="text/javascript" src="popup.js"></script>


### PR DESCRIPTION
I propose this change because it is currently recommended to add rel=”noreferrer noopener” as soon as a link calls for a blank to fill a security breach

I do not know what are the consequences of not putting it in an extension so for security I propose added them

More info about noreferrer and noopener on GHack : https://www.ghacks.net/2017/01/24/web-security-add-relnoopener-to-external-links/