### PR TITLE
Add support of auto dark mode

### DIFF
--- a/chrome/popup.css
+++ b/chrome/popup.css
@@ -58,3 +58,13 @@ label {
     height:48px;
 }
 
+@media (prefers-color-scheme: dark) {
+	body { 
+    	color: #ffffff;
+    	background-color: #323234; 
+  	}
+
+	a {
+    	color: #ffffff;
+	}
+}

--- a/firefox/popup.css
+++ b/firefox/popup.css
@@ -58,3 +58,13 @@ label {
     height:48px;
 }
 
+@media (prefers-color-scheme: dark) {
+	body { 
+    	color: #ffffff;
+    	background-color: #323234; 
+  	}
+
+	a {
+    	color: #ffffff;
+	}
+}


### PR DESCRIPTION
@mlgualtieri 
This code in the CSS will allow the extension to change the background color to honor the prefered color of the user.

For instance on windows if you use firefox or chrome, this code will change the color of the extension if the user change dark to light in the system parameter.

i have took a screen shot of the result on windows 10 with this code (i don't have firefox or a mac for test but it normally work).

![Darkmode Image](https://cdn.discordapp.com/attachments/534038175471894528/595318809032785921/Annotation_2019-07-01_202222.png)

Edit : now i switch to light in windows 10 settings, and it change the color back to the default one 👍 

![Darkmode Image](https://cdn.discordapp.com/attachments/534038175471894528/595320277555085328/Annotation_2019-07-01_202222.png)